### PR TITLE
Using MBSwitch in Storyboard

### DIFF
--- a/MBSwitch/MBSwitch.m
+++ b/MBSwitch/MBSwitch.m
@@ -35,6 +35,8 @@
 }
 
 - (void) awakeFromNib {
+    [super awakeFromNib];
+    [self layoutIfNeeded];
     [self configure];
 }
 


### PR DESCRIPTION
Hi, in order to use MBSwitch in Storyboard I needed to add layoutIfNeeded method in awakeFromNib to force the calculation of MBSwitch's frame because it is (0.0, 0.0, 0.0, 0.0) when loaded from Storyboard.
