### PR TITLE
use initWithCoder instead of awakeFromNib to allow customisation from IB

### DIFF
--- a/MBSwitch/MBSwitch.m
+++ b/MBSwitch/MBSwitch.m
@@ -34,10 +34,12 @@
     return self;
 }
 
-- (void) awakeFromNib {
-    [super awakeFromNib];
-    [self layoutIfNeeded];
-    [self configure];
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    if( (self = [super initWithCoder:aDecoder]) ){
+        [self layoutIfNeeded];
+        [self configure];
+    }
+    return self;
 }
 
 - (void) configure {


### PR DESCRIPTION
xCode has ability to set properties in IB by using "User Defined Runtime Attributes". Unfortunately awakeFromNib is called after those attributes are set and it resets them
